### PR TITLE
Refactor CanvasDOM to use ResizeObserver for dynamic height

### DIFF
--- a/src/official/OfficialExport.jsx
+++ b/src/official/OfficialExport.jsx
@@ -36,11 +36,16 @@ export function CanvasDOM() {
   const htmlRef = useRef();
   useEffect(() => {
     if (htmlRef.current) {
-      // console.log("Height: ", htmlRef.current.getBoundingClientRect().height);
-      // console.log("Size: ", size.height);
-      setPages(htmlRef.current.getBoundingClientRect().height / size.height);
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          setPages(entry.contentRect.height / size.height);
+        }
+      });
+
+      resizeObserver.observe(htmlRef.current);
+      return () => resizeObserver.disconnect();
     }
-  }, [size, htmlRef]);
+  }, [size]);
   return (
     <ScrollControls damping={0.1} offset={1} pages={pages}>
       <AmbientLight />


### PR DESCRIPTION
Implement ResizeObserver in the CanvasDOM component to calculate dynamic page height and remove unused console log statements.